### PR TITLE
Each content-type format should define it's own encoding

### DIFF
--- a/draft-ietf-doh-dns-over-https-latest.mkd
+++ b/draft-ietf-doh-dns-over-https-latest.mkd
@@ -209,8 +209,8 @@ application/dns-udpwireformat type (e.g. ct&body=...).
 
 When using the GET method the URI path MUST contain a query parameter
 with the name of body. The value of the parameter is the content of
-the request encoded with base64url {{RFC4648}}. Using the GET method is
-friendlier to many HTTP cache implementations.
+the request encoded according to its returned media-format specification.
+Using the GET method is friendlier to many HTTP cache implementations.
 
 The DNS API Client SHOULD include an HTTP "Accept:" request header to
 say what type of content can be understood in response. The client


### PR DESCRIPTION
There is a potential conflict between the existing, no-MUST/SHOULD/MAY
text in "The HTTP Request" section that says all GET requests should
be base64 and a later section that says it's true (MUST) for the
wireformat (which makes sense).  But I don't think we need to
require (or suggest) that all content-types have to use this encoding
format, as it may be unnecessary for some simple future version of
encoding.  Instead, let each content-type definition specify how
encoding must happen.