### PR TITLE
We should be as forward looking as possible

### DIFF
--- a/draft-ietf-doh-dns-over-https-latest.mkd
+++ b/draft-ietf-doh-dns-over-https-latest.mkd
@@ -161,7 +161,9 @@ The protocol described here bases its design on the following protocol requireme
 
 * The protocol must ensure interoperable media formats through a
   mandatory to implement format wherein a query must be able to
-  contain one or more EDNS extensions, including those not yet defined.
+  contain future modifications to the DNS protocol including the
+  inclusion of one or more EDNS extensions (including those not yet
+  defined).
 
 * The protocol must use a secure transport that meets the
   requirements for modern HTTPS.


### PR DESCRIPTION
Right now the text only defines that future edns options must be
supported, but (IMHO) we should support all future versions of changes
to the DNS in general, not just future EDNS extensions.  So I proposed
text that rewords a bit to state this and uses EDNS as an example.