### PR TITLE
Added optional "original_transport" parameter to media type.

### DIFF
--- a/draft-ietf-doh-dns-over-https-latest.mkd
+++ b/draft-ietf-doh-dns-over-https-latest.mkd
@@ -49,7 +49,6 @@ informative:
   RFC6950:
   RFC6961:
   RFC7719:
-  RFC7830:
   RFC7858:
   CORS:
     title: "Cross-Origin Resource Sharing"
@@ -443,7 +442,10 @@ MIME subtype name: dns-udpwireformat
 
 Required parameters: n/a
 
-Optional parameters: n/a
+Optional parameters:  original_transport
+The "original_transport" parameter has two defined values,
+"udp" and "tcp". This parameter is only expected to be used by
+servers.
 
 Encoding considerations: This is a binary format. The contents are a
 DNS message as defined in RFC 1035. The format used here is for DNS
@@ -572,6 +574,10 @@ was not able to retrieve a full answer for the query over TCP and is providing
 the best answer it could get. This protocol does not require that a DNS API
 server that cannot get an untruncated answer send back such an answer; it can
 instead send back an HTTP error to indicate that it cannot give a useful answer.
+
+This protocol does not define any use for the "original_transport" optional
+parameter of the application/dns-udpwireformat media type.
+
 
 # Acknowledgments
 


### PR DESCRIPTION
This is to address the issue of draft-ietf-dnsop-dns-wireformat-http needing to say what the original transport was. Covered on the mailing list March 25 and March 30.