### PR TITLE
Added mandatory-to-implement requirements

### DIFF
--- a/draft-ietf-doh-dns-over-https-latest.mkd
+++ b/draft-ietf-doh-dns-over-https-latest.mkd
@@ -150,6 +150,9 @@ body of the HTTP request and the Content-Type request header indicates
 the media type of the message. POST-ed requests are smaller than their
 GET equivalents.
 
+DNS API servers MUST implement receiving DNS API messages over
+both POST and GET methods.
+
 When using the GET method the URI path MUST contain a query parameter
 name-value pair {{QUERYPARAMETER}}
 with the name of "ct" and a value indicating the media-format used for
@@ -205,6 +208,10 @@ DNS API clients using the DNS wire format MAY have one or more EDNS
 options {{RFC6891}} in the request.
 
 The media type is "application/dns-udpwireformat".
+
+DNS API clients and DNS API servers MUST support the
+"application/dns-udpwireformat" media type, and MAY support other
+media types as well. 
 
 ## Examples
 

--- a/draft-ietf-doh-dns-over-https-latest.mkd
+++ b/draft-ietf-doh-dns-over-https-latest.mkd
@@ -145,13 +145,12 @@ other requirements of this section. The DNS API server defines the URI
 used by the request. Configuration and discovery of the URI is done
 out of band from this protocol.
 
+DNS API servers MUST implement both POST and GET methods.
+
 When using the POST method the DNS query is included as the message
 body of the HTTP request and the Content-Type request header indicates
 the media type of the message. POST-ed requests are smaller than their
 GET equivalents.
-
-DNS API servers MUST implement receiving DNS API messages over
-both POST and GET methods.
 
 When using the GET method the URI path MUST contain a query parameter
 name-value pair {{QUERYPARAMETER}}
@@ -207,10 +206,6 @@ DNS API clients using the DNS wire format MAY have one or more EDNS
 options {{RFC6891}} in the request.
 
 The media type is "application/dns-udpwireformat".
-
-DNS API clients and DNS API servers MUST support the
-"application/dns-udpwireformat" media type, and MAY support other
-media types as well. 
 
 ## Examples
 
@@ -433,6 +428,13 @@ one that the client would have directed the same query to if the
 client had initiated the request. This specification does not extend
 DNS resolution privileges to URIs that are not recognized by the
 client as trusted DNS API servers.
+
+## Content Negotiation
+
+In order to maximize interoperability, DNS API clients and DNS API
+servers MUST support the "application/dns-udpwireformat" media
+type. Other media types MAY be used as defined by HTTP Content
+Negotiation ({{RFC7231}} Section 3.4).
 
 # IANA Considerations {#iana}
 


### PR DESCRIPTION
By my unofficial informal tally, there was a strong agreement on application/dns-udpwireformat being mandatory, and both GET and POST mandatory for servers.