### PR TITLE
Rejigbis

### DIFF
--- a/draft-ietf-doh-dns-over-https-latest.mkd
+++ b/draft-ietf-doh-dns-over-https-latest.mkd
@@ -294,33 +294,8 @@ Each DNS request-response pair is matched to one HTTP request-response
 pair. The responses may be processed and transported in any order
 using HTTP's multi-streaming functionality ({{RFC7540}} Section 5).
 
-The Answer section of a DNS response can contain zero or more RRsets.
-(RRsets are defined in {{RFC7719}}.)  According to {{RFC2181}}, each
-resource record in an RRset has Time To Live (TTL)
-freshness information.  Different RRsets in the Answer section can
-have different TTLs, although it is only possible for the HTTP response
-to have a single freshness lifetime.  The HTTP response freshness lifetime
-({{RFC7234}} Section 4.2) should be coordinated with the RRset
-with the smallest TTL in the Answer section of the response.
-Specifically, the HTTP freshness lifetime SHOULD be set to expire at the same time
-any of the DNS resource records in the Answer section reach a 0 TTL.
-The response freshness lifetime
-MUST NOT be greater than that indicated by the DNS resoruce record with the
-smallest TTL in the response.
-
-If the DNS response has no records in the Answer section, and the DNS
-response has an SOA record in the Authority section, the response
-freshness lifetime MUST NOT be greater than the MINIMUM field from that SOA
-record.
-(See {{RFC2308}}.)
-Otherwise, the HTTP response MUST set a freshness lifetime
-({{RFC7234}} Section 4.2) of 0 by using a mechanism such as
-"Cache-Control: no-cache" ({{RFC7234}} Section 5.2.1.4).
-
-A DNS API client that receives a response without an explicit
-freshness lifetime MUST NOT assign that response a heuristic
-freshness ({{RFC7234}} Section 4.2.2.) greater than that indicated by
-the DNS Record with the smallest TTL in the response.
+{{caching}} discusses the relationship between DNS and HTTP
+response caching.
 
 A DNS API server MUST be able to process application/dns-udpwireformat
 request messages.
@@ -360,6 +335,34 @@ A DNS API client may utilize a hierarchy of caches that include both
 HTTP and DNS specific caches. HTTP cache entries may be bypassed with
 HTTP mechanisms such as the "Cache-Control no-cache" directive; however
 DNS caches do not have a similar mechanism.
+
+The Answer section of a DNS response can contain zero or more RRsets.
+(RRsets are defined in {{RFC7719}}.)  According to {{RFC2181}}, each
+resource record in an RRset has Time To Live (TTL)
+freshness information.  Different RRsets in the Answer section can
+have different TTLs, although it is only possible for the HTTP response
+to have a single freshness lifetime.  The HTTP response freshness lifetime
+({{RFC7234}} Section 4.2) should be coordinated with the RRset
+with the smallest TTL in the Answer section of the response.
+Specifically, the HTTP freshness lifetime SHOULD be set to expire at the same time
+any of the DNS resource records in the Answer section reach a 0 TTL.
+The response freshness lifetime
+MUST NOT be greater than that indicated by the DNS resoruce record with the
+smallest TTL in the response.
+
+If the DNS response has no records in the Answer section, and the DNS
+response has an SOA record in the Authority section, the response
+freshness lifetime MUST NOT be greater than the MINIMUM field from that SOA
+record.
+(See {{RFC2308}}.)
+Otherwise, the HTTP response MUST set a freshness lifetime
+({{RFC7234}} Section 4.2) of 0 by using a mechanism such as
+"Cache-Control: no-cache" ({{RFC7234}} Section 5.2.1.4).
+
+A DNS API client that receives a response without an explicit
+freshness lifetime MUST NOT assign that response a heuristic
+freshness ({{RFC7234}} Section 4.2.2.) greater than that indicated by
+the DNS Record with the smallest TTL in the response.
 
 A DOH response that was previously stored in an HTTP cache will
 contain the {{RFC7234}} Age response header indicating the elapsed

--- a/draft-ietf-doh-dns-over-https-latest.mkd
+++ b/draft-ietf-doh-dns-over-https-latest.mkd
@@ -69,7 +69,7 @@ This document defines a specific protocol for sending DNS {{RFC1035}}
 queries and getting DNS responses over HTTP {{RFC7540}} using https://
 (and therefore TLS {{RFC5246}} security for integrity and
 confidentiality). Each DNS query-response pair is mapped into a HTTP
-request-response pair.
+exchange.
 
 The described approach is more than a tunnel over HTTP. It establishes
 default media formatting types for requests and responses but uses
@@ -132,7 +132,9 @@ The protocol described here bases its design on the following protocol requireme
 
 * Supporting insecure HTTP
 
-# The HTTP Request
+# The HTTP Exchange
+
+## The HTTP Request
 
 A DNS API client encodes a single DNS query
 into an HTTP request using either the HTTP GET or POST method and the
@@ -175,7 +177,7 @@ separately.
 DNS API clients can use HTTP/2 padding and compression in the same way
 that other HTTP/2 clients use (or don't use) them.
 
-## DNS Wire Format {#dnswire}
+### DNS Wire Format {#dnswire}
 
 The data payload is the DNS on-the-wire format defined in {{RFC1035}}.
 The format is for DNS over UDP. Note that this is different than the
@@ -197,7 +199,7 @@ options {{RFC6891}} in the request.
 
 The media type is "application/dns-udpwireformat".
 
-## Examples
+### HTTP Request Examples
 
 These examples use HTTP/2 style formatting from {{RFC7540}}.
 
@@ -262,7 +264,7 @@ accept = application/dns-udpwireformat
 
 ~~~~~
 
-# The HTTP Response
+## The HTTP Response
 
 An HTTP response with a 2xx status code ({{RFC7231}} Section 6.3)
 indicates a valid DNS response to the query made in the HTTP
@@ -290,8 +292,8 @@ The DNS response for "application/dns-udpwireformat" in {{dnswire}}
 MAY have one or more EDNS options, depending on the
 extension definition of the extensions given in the DNS request.
 
-Each DNS request-response pair is matched to one HTTP request-response
-pair. The responses may be processed and transported in any order
+Each DNS request-response pair is matched to one HTTP exchange.
+The responses may be processed and transported in any order
 using HTTP's multi-streaming functionality ({{RFC7540}} Section 5).
 
 {{caching}} discusses the relationship between DNS and HTTP
@@ -306,7 +308,7 @@ Media Type) upon receiving a media type it is unable to process.
 This document does not change the definition of any HTTP response codes or
 otherwise proscribe their use.
 
-## Example
+### HTTP Response Example
 
 This is an example response for a query for the IN A records for
 "www.example.com" with recursion turned on. The response bears one

--- a/draft-ietf-doh-dns-over-https-latest.mkd
+++ b/draft-ietf-doh-dns-over-https-latest.mkd
@@ -177,28 +177,6 @@ separately.
 DNS API clients can use HTTP/2 padding and compression in the same way
 that other HTTP/2 clients use (or don't use) them.
 
-### DNS Wire Format {#dnswire}
-
-The data payload is the DNS on-the-wire format defined in {{RFC1035}}.
-The format is for DNS over UDP. Note that this is different than the
-wire format used in {{RFC7858}}.
-Also note that while {{RFC1035}} says "Messages carried by UDP are
-restricted to 512 bytes", that was later updated by {{RFC6891}},
-and this protocol allows DNS on-the-wire format payloads of any size.
-
-When using the GET method, the data payload MUST be encoded with
-base64url {{RFC4648}} and then provided as a variable named
-"dns" to the URI Template expansion. Padding characters for
-base64url MUST NOT be included.
-
-When using the POST method, the data payload MUST NOT be encoded and
-is used directly as the HTTP message body.
-
-DNS API clients using the DNS wire format MAY have one or more EDNS
-options {{RFC6891}} in the request.
-
-The media type is "application/dns-udpwireformat".
-
 ### HTTP Request Examples
 
 These examples use HTTP/2 style formatting from {{RFC7540}}.
@@ -430,6 +408,28 @@ In order to maximize interoperability, DNS API clients and DNS API
 servers MUST support the "application/dns-udpwireformat" media
 type. Other media types MAY be used as defined by HTTP Content
 Negotiation ({{RFC7231}} Section 3.4).
+
+# DNS Wire Format {#dnswire}
+
+The data payload is the DNS on-the-wire format defined in {{RFC1035}}.
+The format is for DNS over UDP. Note that this is different than the
+wire format used in {{RFC7858}}.
+Also note that while {{RFC1035}} says "Messages carried by UDP are
+restricted to 512 bytes", that was later updated by {{RFC6891}},
+and this protocol allows DNS on-the-wire format payloads of any size.
+
+When using the GET method, the data payload MUST be encoded with
+base64url {{RFC4648}} and then provided as a variable named
+"dns" to the URI Template expansion. Padding characters for
+base64url MUST NOT be included.
+
+When using the POST method, the data payload MUST NOT be encoded and
+is used directly as the HTTP message body.
+
+DNS API clients using the DNS wire format MAY have one or more EDNS
+options {{RFC6891}} in the request.
+
+The media type is "application/dns-udpwireformat".
 
 # IANA Considerations {#iana}
 

--- a/draft-ietf-doh-dns-over-https-latest.mkd
+++ b/draft-ietf-doh-dns-over-https-latest.mkd
@@ -92,7 +92,7 @@ other uses for this work.
 
 # Terminology
 
-A server that supports this protocol is called a "DNS API server" to
+A server that supports this protocol on one or more URIs is called a "DNS API server" to
 differentiate it from a "DNS server" (one that uses the regular DNS
 protocol).  Similarly, a client that supports this protocol is called a
 "DNS API client".


### PR DESCRIPTION
this is meant as simpler alternative to #134. Its much less of a rewrite.

* consolidates caching rules by moving text
* adds a new section header "HTTP Exchange" for request and response to fall under
* moves the wireformat definition out of the  http sections by moving text.