### PR TITLE
Simplify the abstract

### DIFF
--- a/draft-ietf-doh-dns-over-https-latest.mkd
+++ b/draft-ietf-doh-dns-over-https-latest.mkd
@@ -58,16 +58,15 @@ informative:
 
 --- abstract
 
-This document describes how to run DNS service over HTTP (DOH) using
-https:// URIs.
+This document describes how to make DNS queries using HTTPS.
 
 --- middle
 
 # Introduction
 
 This document defines a specific protocol for sending DNS {{RFC1035}}
-queries and getting DNS responses over HTTP {{RFC7540}} using https://
-(and therefore TLS {{RFC5246}} security for integrity and
+queries and getting DNS responses over HTTP {{RFC7540}} using https
+URIs (and therefore TLS {{RFC5246}} security for integrity and
 confidentiality). Each DNS query-response pair is mapped into a HTTP
 exchange.
 

--- a/draft-ietf-doh-dns-over-https-latest.mkd
+++ b/draft-ietf-doh-dns-over-https-latest.mkd
@@ -1,6 +1,6 @@
 ---
-title: DNS Queries over HTTPS
-abbrev: DNS Queries over HTTPS
+title: DNS Queries over HTTPS (DOH)
+abbrev: DNS Queries over HTTPS (DOH)
 docname: draft-ietf-doh-dns-over-https
 
 stand_alone: true
@@ -58,7 +58,7 @@ informative:
 
 --- abstract
 
-This document describes how to make DNS queries using HTTPS.
+This document describes how to make DNS queries over HTTPS.
 
 --- middle
 


### PR DESCRIPTION
The "using https:// URIs" part is just odd.  Easier to simply state that this uses HTTPS at this level.

Also, if the concept of a DNS service evolves to encompass other types of exchange than simple request-response, then "run DNS service" won't be accurate.