### PR TITLE
Reword sentence that begs a very particular question

### DIFF
--- a/draft-ietf-doh-dns-over-https-latest.mkd
+++ b/draft-ietf-doh-dns-over-https-latest.mkd
@@ -87,8 +87,8 @@ Two primary uses cases were considered during this protocol's
 development. They included preventing on-path devices from interfering
 with DNS operations and allowing web applications to access DNS
 information via existing browser APIs in a safe way consistent with
-Cross Origin Resource Sharing (CORS) {{CORS}}. There are certainly
-other uses for this work.
+Cross Origin Resource Sharing (CORS) {{CORS}}. No special effort has
+been taken to enable or prevent application to other use cases.
 
 # Terminology
 


### PR DESCRIPTION
When a statement is so definite, the reader tends to assume that there is something more to be said.  In this case, the obvious question is "what other uses are there?", closely followed by "and what reason could the authors have had for not mentioning them?"