### PR TITLE
Remove unnecessary qualification

### DIFF
--- a/draft-ietf-doh-dns-over-https-latest.mkd
+++ b/draft-ietf-doh-dns-over-https-latest.mkd
@@ -92,7 +92,7 @@ other uses for this work.
 
 # Terminology
 
-A server that supports this protocol on one or more URIs is called a "DNS API server" to
+A server that supports this protocol is called a "DNS API server" to
 differentiate it from a "DNS server" (one that uses the regular DNS
 protocol).  Similarly, a client that supports this protocol is called a
 "DNS API client".


### PR DESCRIPTION
This isn't necessary.  I realize that this reverts a deliberate change as part of #139, but if it is important to describe - which I don't think helps - then I don't think that this is the right approach.

Adding an explicit statement would be better.