### PR TITLE
Remove weird text about DNSSEC

### DIFF
--- a/draft-ietf-doh-dns-over-https-latest.mkd
+++ b/draft-ietf-doh-dns-over-https-latest.mkd
@@ -497,8 +497,7 @@ the authenticity of DNS data. A DNS API client may also perform full
 DNSSEC validation of answers received from a DNS API server or it may
 choose to trust answers from a particular DNS API server, much as a
 DNS client might choose to trust answers from its recursive DNS
-resolver. This capability might be affected by the response media
-type.
+resolver.
 
 {{caching}} describes the interaction of this protocol with HTTP
 caching. An adversary that can control the cache used by the client


### PR DESCRIPTION
I couldn't understand this statement.  It's perfectly OK without it, so I'm suggesting that it be removed.  If this isn't the right approach, then I'd like to understand why.  As it is, this sentence is a land-mine.