### PR TITLE
Remove the protocol requirements before becoming an RFC

### DIFF
--- a/draft-ietf-doh-dns-over-https-latest.mkd
+++ b/draft-ietf-doh-dns-over-https-latest.mkd
@@ -107,6 +107,8 @@ appear in all capitals, as shown here.
 
 # Protocol Requirements
 
+\[\[ RFC Editor: Please remove this entire section before publication. \]\]
+
 The protocol described here bases its design on the following protocol requirements:
 
 * The protocol must use normal HTTP semantics.
@@ -407,6 +409,10 @@ In order to maximize interoperability, DNS API clients and DNS API
 servers MUST support the "application/dns-message" media
 type. Other media types MAY be used as defined by HTTP Content
 Negotiation ({{RFC7231}} Section 3.4).
+Those media types MUST be flexible enough to express every
+DNS query that would normally be sent in DNS over UDP (including queries and
+responses that use DNS extensions, but not those that require multiple
+responses).
 
 # DNS Wire Format {#dnswire}
 


### PR DESCRIPTION
… but keep the requirement for future formats.