### PR TITLE
Remove text about client caches

### DIFF
--- a/draft-ietf-doh-dns-over-https-latest.mkd
+++ b/draft-ietf-doh-dns-over-https-latest.mkd
@@ -517,7 +517,7 @@ than the security implications of HTTP caching for other protocols
 that use HTTP.
 
 In the absence of information about the authenticity of responses, such as
-DNSSEC, a DNS API server can poison a client's cache. A
+DNSSEC, a DNS API server can give a client invalid data in responses. A
 client MUST NOT authorize arbitrary DNS API servers.
 Instead, a client MUST specifically authorize DNS
 API servers using mechanisms such as explicit configuration.


### PR DESCRIPTION
This is the only place where a client cache is mentioned, and stub resolvers normally don't have caches. (Some browsers have caches for the stub resolvers, but this is rare and not well known outside a small group of people.) This change replaces that one instance with wording that still explains the main problem.