### PR TITLE
Security: update text about DNS server choice

### DIFF
--- a/draft-ietf-doh-dns-over-https-latest.mkd
+++ b/draft-ietf-doh-dns-over-https-latest.mkd
@@ -520,11 +520,10 @@ can affect that client's view of the DNS. This is no different
 than the security implications of HTTP caching for other protocols
 that use HTTP.
 
-In the absence of information about the authenticity of responses, such as
-DNSSEC, a DNS API server can give a client invalid data in responses. A
-client MUST NOT authorize arbitrary DNS API servers.
-Instead, a client MUST specifically authorize DNS
-API servers using mechanisms such as explicit configuration.
+When DNSSEC is not used, a DNS API server can give the client invalid
+data as a response to a DNS query. Therefore, a DNS API client SHOULD
+carefully determine which DNS API server(s) it trusts. For example, a
+DNS API client can have trusted DNS API server(s) preconfigured.
 
 A client can use DNS over HTTPS as one of multiple mechanisms to obtain DNS
 data. If a client of this protocol encounters an HTTP error after sending


### PR DESCRIPTION
The current text is difficult to understand, so replace it with
something clearer.

This is in connection to the following mail:
        https://www.ietf.org/mail-archive/web/doh/current/msg00543.html

I suppose that most computer users won't know what a DNS is and won't configure
a DNS API server themselves. Therefore, "explicit configuration" in practice
means a "preconfigured DNS API server(s)".