### PR TITLE
Merge "Selection of DNS API Server" into "Security Considerations"

### DIFF
--- a/draft-ietf-doh-dns-over-https-latest.mkd
+++ b/draft-ietf-doh-dns-over-https-latest.mkd
@@ -141,19 +141,6 @@ The protocol described here bases its design on the following protocol requireme
 
 * Supporting insecure HTTP
 
-# Selection of DNS API Server
-
-Before using a DNS API server for DNS resolution, the client MUST establish that
-the HTTP request URI is a trusted service for the DOH query, in other words, a
-DNS API client MUST only use a DNS API server that is configured as trustworthy.
-
-A client MUST NOT use a DNS API server simply because it was discovered, or
-because the client was told to use the DNS API server by an untrusted party.
-
-This specification does not extend DNS resolution privileges to URIs that are
-not recognized by the DNS API client as trusted DNS API servers. As such, use of
-untrusted servers is out of scope of this document.
-
 # The HTTP Exchange
 
 ## The HTTP Request
@@ -542,6 +529,11 @@ client MUST NOT use arbitrary DNS API servers.
 Instead, a client MUST only use DNS
 API servers specified using mechanisms such as explicit configuration. This does
 not guarantee protection against invalid data but reduces the risk.
+
+This specification does not extend DNS resolution privileges to URIs that are
+not recognized by the DNS API client as trusted DNS API servers (that are
+not specified using mechanisms such as explicit configuration). As such, use of
+untrusted servers is out of scope of this document.
 
 A client can use DNS over HTTPS as one of multiple mechanisms to obtain DNS
 data. If a client of this protocol encounters an HTTP error after sending


### PR DESCRIPTION
The specification currently describes choice of DNS API servers in two
different places: "Selection of DNS API Server" and "Security
considerations". The information presented in "Selection of
DNS API Server" is mostly a duplication.

This patch removes duplicate information and moves the remaining portion
of "Selection of DNS API Server" into "Security considerations".