### PR TITLE
Selection of DNS API Server: make it a copy of "Security Considerations"

### DIFF
--- a/draft-ietf-doh-dns-over-https-latest.mkd
+++ b/draft-ietf-doh-dns-over-https-latest.mkd
@@ -142,16 +142,10 @@ The protocol described here bases its design on the following protocol requireme
 
 # Selection of DNS API Server
 
-Before using a DNS API server for DNS resolution, the client MUST establish that
-the HTTP request URI is a trusted service for the DOH query, in other words, a
-DNS API client MUST only use a DNS API server that is configured as trustworthy.
-
-A client MUST NOT use a DNS API server simply because it was discovered, or
-because the client was told to use the DNS API server by an untrusted party.
-
-This specification does not extend DNS resolution privileges to URIs that are
-not recognized by the DNS API client as trusted DNS API servers. As such, use of
-untrusted servers is out of scope of this document.
+As specified in the section "Security considerations",
+a client MUST NOT use arbitrary DNS API servers.
+Instead, a client MUST only use DNS
+API servers specified using mechanisms such as explicit configuration.
 
 # The HTTP Exchange
 
@@ -551,6 +545,9 @@ A client MUST NOT use arbitrary DNS API servers.
 Instead, a client MUST only use DNS
 API servers specified using mechanisms such as explicit configuration. This does
 not guarantee protection against invalid data but reduces the risk.
+This specification does not extend DNS resolution privileges to URIs that are
+not recognized by the DNS API client as trusted DNS API servers. As such, use of
+untrusted servers is out of scope of this document.
 
 A client can use DNS over HTTPS as one of multiple mechanisms to obtain DNS
 data. If a client of this protocol encounters an HTTP error after sending


### PR DESCRIPTION
Both section "Security Considerations" and section "Selection of DNS API
Server" specify which server the client may use but in a different way:

	[...] the client MUST
	establish that the HTTP request URI is a trusted service for the DOH
	query, in other words, a DNS API client MUST only use a DNS API server
	that is configured as trustworthy.

vs

	A client MUST NOT use arbitrary DNS API servers. Instead, a client MUST
	only use DNS API servers specified using mechanisms such as explicit
	configuration.

Such discrepancy was confusing.

If there should be a section "Selection of DNS API Server", the text
there should be just a repetition of what is said in "Security
considerations".