### PR TITLE
informative reference to https/2818

### DIFF
--- a/draft-ietf-doh-dns-over-https-latest.mkd
+++ b/draft-ietf-doh-dns-over-https-latest.mkd
@@ -44,6 +44,7 @@ normative:
   RFC8174:
 
 informative:
+  RFC2818:
   RFC5280:
   RFC5861:
   RFC6066:
@@ -144,7 +145,9 @@ The protocol described here bases its design on the following protocol requireme
 
 Before using a DNS API server for DNS resolution, the client MUST establish that
 the HTTP request URI is a trusted service for the DOH query, in other words, a
-DNS API client MUST only use a DNS API server that is configured as trustworthy.
+DNS API client MUST only use a DNS API server that is configured as
+trustworthy. {{RFC2818}} defines how HTTPS verifies the identity of
+a connection with the trusted service.
 
 A client MUST NOT use a DNS API server simply because it was discovered, or
 because the client was told to use the DNS API server by an untrusted party.


### PR DESCRIPTION
clarify that server identity authentication is part of https.