### PR TITLE
Mention draft-ietf-dprive-padding-policy which provides guidelines

### DIFF
--- a/draft-ietf-doh-dns-over-https-latest.mkd
+++ b/draft-ietf-doh-dns-over-https-latest.mkd
@@ -631,7 +631,7 @@ DNS queries.
 HTTP/2 provides further advice about the use of compression
 ({{RFC7540}} Section 10.6) and padding ({{RFC7540}} Section 10.7 ).
 DoH Servers can also add DNS padding {{RFC7830}} if the DoH client requests
-it in the DNS query. Additionally, guidelines for choosing the padding length
+it in the DNS query. Initial attempts to offer guidance on choosing the padding length
 can be found in {{draft-ietf-dprive-padding-policy}}.
 
 The HTTPS connection provides transport security for the interaction between the

--- a/draft-ietf-doh-dns-over-https-latest.mkd
+++ b/draft-ietf-doh-dns-over-https-latest.mkd
@@ -631,7 +631,8 @@ DNS queries.
 HTTP/2 provides further advice about the use of compression
 ({{RFC7540}} Section 10.6) and padding ({{RFC7540}} Section 10.7 ).
 DoH Servers can also add DNS padding {{RFC7830}} if the DoH client requests
-it in the DNS query.
+it in the DNS query. Additionally, guidelines for choosing the padding length
+can be found in {{draft-ietf-dprive-padding-policy}}.
 
 The HTTPS connection provides transport security for the interaction between the
 DoH server and client, but does not provide the response integrity of DNS

--- a/draft-ietf-doh-dns-over-https-latest.mkd
+++ b/draft-ietf-doh-dns-over-https-latest.mkd
@@ -631,8 +631,8 @@ DNS queries.
 HTTP/2 provides further advice about the use of compression
 ({{RFC7540}} Section 10.6) and padding ({{RFC7540}} Section 10.7 ).
 DoH Servers can also add DNS padding {{RFC7830}} if the DoH client requests
-it in the DNS query. Initial attempts to offer guidance on choosing the padding length
-can be found in {{draft-ietf-dprive-padding-policy}}.
+it in the DNS query. Initial attempts to offer guidance on choosing the padding 
+length can be found in {{draft-ietf-dprive-padding-policy}}.
 
 The HTTPS connection provides transport security for the interaction between the
 DoH server and client, but does not provide the response integrity of DNS


### PR DESCRIPTION
on padding length which was absent from RFC 7830.